### PR TITLE
Disable default unique slug generation so slug validation rule 'uniqu…

### DIFF
--- a/src/Models/Attribute.php
+++ b/src/Models/Attribute.php
@@ -232,6 +232,7 @@ class Attribute extends Model implements Sortable
         return SlugOptions::create()
                           ->doNotGenerateSlugsOnUpdate()
                           ->generateSlugsFrom('name')
+                          ->allowDuplicateSlugs()
                           ->saveSlugsTo('slug');
     }
 


### PR DESCRIPTION
…e' is applicable

Currently, duplicate attribute names are allowed.  Looking at the rules in _Attribute.php_ model, it appears this is not desirable because of the 'unique' rule on 'slug'.

**Attribute.php:**
```
    public function __construct(array $attributes = [])
    {
        parent::__construct($attributes);

        $this->setTable(config('rinvex.attributes.tables.attributes'));
        $this->setRules([
            'name' => 'required|string|max:150',
            'description' => 'nullable|string|max:10000',
            'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.attributes.tables.attributes').',slug',
            'sort_order' => 'nullable|integer|max:10000000',
            'group' => 'nullable|string|max:150',
            'type' => 'required|string|max:150',
            'is_required' => 'sometimes|boolean',
            'is_collection' => 'sometimes|boolean',
            'default' => 'nullable|string|max:10000',
        ]);
    }
```

Since spatie/laravel-sluggable makes all slugs unique by default by appending a dash and a number to the end, this rule will never be enforced ([see sluggable docs](https://packagist.org/packages/spatie/laravel-sluggable)).  In order to prevent this default behavior, `allowDuplicateSlugs()` should be called.  Then, any attempt to save an attribute with an existing name will result in an error.