### PR TITLE
Significant performance improvement by bypassing Eloquent model magic

### DIFF
--- a/src/Support/RelationBuilder.php
+++ b/src/Support/RelationBuilder.php
@@ -27,7 +27,7 @@ class RelationBuilder
         foreach ($attributes as $attribute) {
             $relation = $this->getRelationClosure($entity, $attribute);
 
-            $entity->setEntityAttributeRelation($attribute->getAttribute('slug'), $relation);
+            $entity->setEntityAttributeRelation((string)($attribute->getAttributes()['slug'] ?? null), $relation);
         }
     }
 
@@ -41,7 +41,7 @@ class RelationBuilder
      */
     protected function getRelationClosure(Entity $entity, Attribute $attribute): Closure
     {
-        $method = $attribute->is_collection ? 'hasMany' : 'hasOne';
+        $method = (bool)($attribute->getAttributes()['is_collection'] ?? null) ? 'hasMany' : 'hasOne';
 
         // This will return a closure fully binded to the current entity instance,
         // which will help us to simulate any relation as if it was made in the

--- a/src/Support/RelationBuilder.php
+++ b/src/Support/RelationBuilder.php
@@ -27,7 +27,7 @@ class RelationBuilder
         foreach ($attributes as $attribute) {
             $relation = $this->getRelationClosure($entity, $attribute);
 
-            $entity->setEntityAttributeRelation((string)($attribute->getAttributes()['slug'] ?? null), $relation);
+            $entity->setEntityAttributeRelation((string) ($attribute->getAttributes()['slug'] ?? null), $relation);
         }
     }
 
@@ -41,7 +41,7 @@ class RelationBuilder
      */
     protected function getRelationClosure(Entity $entity, Attribute $attribute): Closure
     {
-        $method = (bool)($attribute->getAttributes()['is_collection'] ?? null) ? 'hasMany' : 'hasOne';
+        $method = (bool) ($attribute->getAttributes()['is_collection'] ?? null) ? 'hasMany' : 'hasOne';
 
         // This will return a closure fully binded to the current entity instance,
         // which will help us to simulate any relation as if it was made in the


### PR DESCRIPTION
When accessing Eloquent model attributes via `$model->getAttribute(...)` or `$model->attribute`, Eloquent will check if the attribute needs to be cast or mutated. This adds significant processing time when accessing attributes so instead we bypass this by calling `$model->getAttributes()['attribute']` and casting it ourselves.