### PR TITLE
FIX trash multiple attribute types in one save

### DIFF
--- a/src/Events/EntityWasSaved.php
+++ b/src/Events/EntityWasSaved.php
@@ -57,11 +57,15 @@ class EntityWasSaved
             }
 
             if ($this->trash->count()) {
-                // Fetch the first item's class to know the model used for deletion
-                $class = get_class($this->trash->first());
-
-                // Let's batch delete all the values based on their ids
-                $class::whereIn('id', $this->trash->pluck('id'))->delete();
+                $this->trash->mapToGroups(function ($item, $key) {
+                    return [get_class($item) => $item];
+                })->reduce(function ($carry, $group) {
+                    $trash = collect($group);
+                    // Fetch the first item's class to know the model used for deletion
+                    $class = get_class($trash->first());
+                    // Let's batch delete all the values based on their ids
+                    return true && $class::whereIn('id', $trash->pluck('id'))->delete();
+                }, true);
 
                 // Now, empty the trash
                 $this->trash = collect([]);

--- a/src/Events/EntityWasSaved.php
+++ b/src/Events/EntityWasSaved.php
@@ -57,14 +57,14 @@ class EntityWasSaved
             }
 
             if ($this->trash->count()) {
-                $this->trash->mapToGroups(function ($item, $key) {
+                $this->trash->mapToGroups(function ($item) {
                     return [get_class($item) => $item];
                 })->reduce(function ($carry, $group) {
                     $trash = collect($group);
                     // Fetch the first item's class to know the model used for deletion
                     $class = get_class($trash->first());
                     // Let's batch delete all the values based on their ids
-                    return true && $class::whereIn('id', $trash->pluck('id'))->delete();
+                    return $carry && $class::whereIn('id', $trash->pluck('id'))->delete();
                 }, true);
 
                 // Now, empty the trash


### PR DESCRIPTION
Fixes issue when trashing/replacing multiple attribute types leads to data integrity issues (deleting IDs in different/first found model) and duplicating data (especially for replace in collections).