### PR TITLE
FIX: Make values always be a collection when force deleting. Fixes #90.

### DIFF
--- a/src/Events/EntityWasDeleted.php
+++ b/src/Events/EntityWasDeleted.php
@@ -28,7 +28,7 @@ class EntityWasDeleted
 
         foreach ($entity->getEntityAttributes() as $attribute) {
             if ($entity->relationLoaded($relation = $attribute->getAttribute('slug'))
-                && ($values = $entity->getRelationValue($relation)) && ! $values->isEmpty()) {
+                && ($values = \Illuminate\Support\Collection::wrap($entity->getRelationValue($relation))) && ! $values->isEmpty()) {
                 // Calling the `destroy` method from the given $type model class name
                 // will finally delete the records from database if any was found.
                 // We'll just provide an array containing the ids to be deleted.


### PR DESCRIPTION
Just wrap the `$values` variable in a collection.
If it was a single value, now it is a collection and the `isEmpty()` method will not throw an Exception.
If it was already a collection, nothing changes.