### PR TITLE
Adding indexes for attribute values

### DIFF
--- a/database/migrations/2020_10_14_000001_add_attribute_value_indexes.php
+++ b/database/migrations/2020_10_14_000001_add_attribute_value_indexes.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAttributeValueIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(config('rinvex.attributes.tables.attribute_boolean_values'), function (Blueprint $table) {
+            $table->index(['attribute_id', 'entity_id', 'entity_type'], 'attribute_boolean_values_index');
+            $table->index(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_datetime_values'), function (Blueprint $table) {
+            $table->index(['attribute_id', 'entity_id', 'entity_type'], 'attribute_datetime_values_index');
+            $table->index(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_integer_values'), function (Blueprint $table) {
+            $table->index(['attribute_id', 'entity_id', 'entity_type'], 'attribute_integer_values_index');
+            $table->index(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_text_values'), function (Blueprint $table) {
+            $table->index(['attribute_id', 'entity_id', 'entity_type'], 'attribute_text_values_index');
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_varchar_values'), function (Blueprint $table) {
+            $table->index(['attribute_id', 'entity_id', 'entity_type'], 'attribute_varchar_values_index');
+            $table->index(['content']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(config('rinvex.attributes.tables.attribute_boolean_values'), function (Blueprint $table) {
+            $table->dropIndex('attribute_boolean_values_index');
+            $table->dropIndex(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_datetime_values'), function (Blueprint $table) {
+            $table->dropIndex('attribute_datetime_values_index');
+            $table->dropIndex(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_integer_values'), function (Blueprint $table) {
+            $table->dropIndex('attribute_integer_values_index');
+            $table->dropIndex(['content']);
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_text_values'), function (Blueprint $table) {
+            $table->dropIndex('attribute_text_values_index');
+        });
+        Schema::table(config('rinvex.attributes.tables.attribute_varchar_values'), function (Blueprint $table) {
+            $table->dropIndex('attribute_varchar_values_index');
+            $table->dropIndex(['content']);
+        });
+    }
+}

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -7,6 +7,7 @@ namespace Rinvex\Attributes\Tests\Feature;
 use Rinvex\Attributes\Models\Attribute;
 use Rinvex\Attributes\Tests\Stubs\User;
 use Rinvex\Attributes\Providers\AttributesServiceProvider;
+use Rinvex\Support\Providers\SupportServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -45,6 +46,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         return [
             AttributesServiceProvider::class,
+            SupportServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
This pull request adds indexes for each of the attribute value tables and the performance improvement is noticeable when using a large number attributes and entities. 

I have not fully tested the performance improvement of the single column indexes for the `content` field, but it may be helpful when searching for attributes with specific values.

A commit to address issues with the tests not running has also been included, but this can be split out if preferred.