### PR TITLE
WIP: Update laravel version to allow Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,11 +49,11 @@
     ],
     "require": {
         "php": "^7.4.0",
-        "illuminate/console": "^7.0.0",
-        "illuminate/database": "^7.0.0",
-        "illuminate/support": "^7.0.0",
+        "illuminate/console": "^7.0.0|^8.0.0",
+        "illuminate/database": "^7.0.0|^8.0.0",
+        "illuminate/support": "^7.0.0|^8.0.0",
         "jeremeamia/superclosure": "^2.4.0",
-        "rinvex/laravel-support": "^4.0.0",
+        "rinvex/laravel-support": "^4.0.0|^5.0.0",
         "spatie/eloquent-sortable": "^3.7.0",
         "spatie/laravel-sluggable": "^2.2.0",
         "spatie/laravel-translatable": "^4.2.0"


### PR DESCRIPTION
# Update laravel version to allow Laravel 8

## Updated dependencies
* `illuminate/*`
* `rinvex/laravel-support`

## Waiting for update
* `rinvex/laravel-support:5.0.0` (PR : https://github.com/rinvex/laravel-support/pull/41)